### PR TITLE
adds support for PhantomJS to PropertyWebDriverProvider

### DIFF
--- a/web-selenium/pom.xml
+++ b/web-selenium/pom.xml
@@ -69,6 +69,11 @@
       <version>2.14.1</version>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>com.github.detro.ghostdriver</groupId>
+      <artifactId>phantomjsdriver</artifactId>
+      <version>1.0.4</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/web-selenium/src/main/java/org/jbehave/web/selenium/PropertyWebDriverProvider.java
+++ b/web-selenium/src/main/java/org/jbehave/web/selenium/PropertyWebDriverProvider.java
@@ -10,6 +10,7 @@ import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 import org.openqa.selenium.ie.InternetExplorerDriver;
+import org.openqa.selenium.phantomjs.PhantomJSDriver;
 
 import static java.lang.Boolean.parseBoolean;
 
@@ -21,6 +22,7 @@ import static java.lang.Boolean.parseBoolean;
  * <li>"firefox": {@link FirefoxDriver}</li>
  * <li>"htmlunit": {@link HtmlUnitDriver}</li>
  * <li>"ie": {@link InternetExplorerDriver}</li>
+ * <li>"phantomjs": {@link PhantomJSDriver}</li>
  * </ul>
  * Property values are case-insensitive and defaults to "firefox" if no
  * "browser" system property is found.
@@ -37,7 +39,7 @@ import static java.lang.Boolean.parseBoolean;
 public class PropertyWebDriverProvider extends DelegatingWebDriverProvider {
 
     public enum Browser {
-        ANDROID, CHROME, FIREFOX, HTMLUNIT, IE
+        ANDROID, CHROME, FIREFOX, HTMLUNIT, IE, PHANTOMJS
     }
 
     public void initialize() {
@@ -58,6 +60,8 @@ public class PropertyWebDriverProvider extends DelegatingWebDriverProvider {
             return createHtmlUnitDriver();
         case IE:
             return createInternetExplorerDriver();
+        case PHANTOMJS:
+            return createPhantomJSDriver();
         }
     }
 
@@ -92,7 +96,11 @@ public class PropertyWebDriverProvider extends DelegatingWebDriverProvider {
     protected InternetExplorerDriver createInternetExplorerDriver() {
         return new InternetExplorerDriver();
     }
-    
+
+    protected WebDriver createPhantomJSDriver() {
+        return new PhantomJSDriver();
+    }
+
     protected Locale usingLocale() {
         return Locale.getDefault();
     }

--- a/web-selenium/src/test/java/org/jbehave/web/selenium/PropertyWebDriverProviderTest.java
+++ b/web-selenium/src/test/java/org/jbehave/web/selenium/PropertyWebDriverProviderTest.java
@@ -8,6 +8,7 @@ import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 import org.openqa.selenium.ie.InternetExplorerDriver;
+import org.openqa.selenium.phantomjs.PhantomJSDriver;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -65,7 +66,14 @@ public class PropertyWebDriverProviderTest {
         createProviderForProperty("ie");
         assertThat(provider.get(), instanceOf(InternetExplorerDriver.class));
     }
-    
+
+    @Test
+    @Ignore("Only when PhantomJS is available")
+    public void shouldSupportPhantomJSByProperty() {
+        createProviderForProperty("phantomjs");
+        assertThat(provider.get(), instanceOf(PhantomJSDriver.class));
+    }
+
     private void createProviderForProperty(String browser) {
         if (browser != null) {
             System.setProperty("browser", browser);


### PR DESCRIPTION
JBehave/Selenium has been integrated with PhantomJS via [GhostDriver](https://github.com/detro/ghostdriver).

This pull request adds support for specifying -Dbrowser=phantomjs to the PropertyWebDriverProvider class.

I've added a test too but it's disabled as you need to have the phantomjs binary on your $PATH for it to run...
