### PR TITLE
Updated links in the "Related" section of the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Note:  profiles are additive and the default profile is always active.
 
 ## Related
 
-See also the [jbehave-core](jbehave-core) sister project for web extensions to JBehave, and [jbehave-tutorial](jbehave-tutorial) for a decent example of JBehave testing of a web application.
+See also the [jbehave-core](https://github.com/jbehave/jbehave-core) sister project for web extensions to JBehave, and [jbehave-tutorial](https://github.com/jbehave/jbehave-tutorial) for a decent example of JBehave testing of a web application.
 
 ## License
 


### PR DESCRIPTION
Hello, for a bit of context I am currently studying computer science in university. This year I was asked to study an open source project and then contribute to it.
I obviously chose your project and during the process of studying it I found a few deprecated links in some of your repositories' documentation.

It may not be much but for my first contribution I updated some of those links.

Here is the list of deprecated links I managed to find:
- the links in the [Related](https://github.com/jbehave/jbehave-web#related) section of the jbehave-web repository (solved in this  PR)
- the links in the [Related JBehave projects](https://github.com/jbehave/jbehave-pom#related-jbehave-projects) section of the jbehave-pom repository
- the links in the [Inspiration](https://github.com/jbehave/jbehave-eclipse#inspiration) section of the jbehave-eclipse repository 